### PR TITLE
fix: no API Key confirmation on account double click

### DIFF
--- a/TradeOnSda/TradeOnSda/Views/Account/AccountViewModel.cs
+++ b/TradeOnSda/TradeOnSda/Views/Account/AccountViewModel.cs
@@ -136,7 +136,7 @@ public class AccountViewModel : ViewModelBase
         SelectStrategyAsync(DefaultAccountViewCommandStrategy).GetAwaiter().GetResult();
 
         IsUnknownProxyState = true;
-        
+
         SdaWithCredentials.SdaState.WhenPropertyChanged(t => t.ProxyState)
             .Subscribe(valueWrapper =>
             {
@@ -161,7 +161,7 @@ public class AccountViewModel : ViewModelBase
                         break;
                 }
             });
-        
+
         FirstCommand = ReactiveCommand.CreateFromTask(async () =>
         {
             await SelectedAccountViewCommandStrategy.InvokeFirstCommandAsync();
@@ -179,24 +179,7 @@ public class AccountViewModel : ViewModelBase
 
         DoubleClickCommand = ReactiveCommand.CreateFromTask(async () =>
         {
-            try
-            {
-                var confirmations = (await SdaWithCredentials.SteamGuardAccount.FetchConfirmationAsync()).Where(t =>
-                    t.ConfirmationType is ConfirmationType.Trade or ConfirmationType.MarketSellTransaction
-                        or ConfirmationType.Recovery).ToArray();
-
-                var window = new ConfirmationsWindow(confirmations, SdaWithCredentials.SteamGuardAccount);
-
-                window.Show();
-            }
-            catch (RequestException e)
-            {
-                await NotificationsMessageWindow.ShowWindow($"Cannot load confirmations. {e}", OwnerWindow);
-            }
-            catch (Exception e)
-            {
-                await NotificationsMessageWindow.ShowWindow($"Cannot load confirmations, message: {e.Message}", OwnerWindow);
-            }
+            await SelectedAccountViewCommandStrategy.InvokeSecondCommandAsync();
         });
 
         ToggleAutoConfirmCommand = ReactiveCommand.CreateFromTask(async () =>
@@ -233,7 +216,7 @@ public class AccountViewModel : ViewModelBase
             }
 
             sdaWithCredentials.SdaSettings.AutoConfirmDelay = TimeSpan.FromSeconds(delay);
-            
+
             await SdaManager.SaveSettingsAsync();
 
             var _ = Task.Run(async () =>

--- a/TradeOnSda/TradeOnSda/Views/ConfirmationItem/ConfirmationItemViewModel.cs
+++ b/TradeOnSda/TradeOnSda/Views/ConfirmationItem/ConfirmationItemViewModel.cs
@@ -20,7 +20,7 @@ namespace TradeOnSda.Views.ConfirmationItem;
 public class ConfirmationItemViewModel : ViewModelBase
 {
     private IImage? _userImage;
-    
+
     public SteamGuardAccount SteamGuardAccount { get; }
 
     public SdaConfirmation SdaConfirmation { get; }
@@ -45,13 +45,13 @@ public class ConfirmationItemViewModel : ViewModelBase
         {
             ConfirmationType.Trade => "Trade",
             ConfirmationType.MarketSellTransaction => "Market",
-            ConfirmationType.Recovery => "Account",
+            ConfirmationType.Recovery or ConfirmationType.WebKey => "Account",
             _ => "",
         };
 
         var creationTime = TimeHelpers.FromTimeStamp(sdaConfirmation.CreationTimeStamp);
         var delta = DateTime.UtcNow - creationTime;
-        
+
         var humanizedTime = delta.Humanize(2, new CultureInfo("en-US"));
         ConfirmationTime = humanizedTime + " ago";
 
@@ -69,7 +69,7 @@ public class ConfirmationItemViewModel : ViewModelBase
             try
             {
                 await SteamGuardAccount.AcceptConfirmationAsync(SdaConfirmation);
-                
+
                 confirmationsViewModel.RemoveViewModel(this);
             }
             catch (RequestException e)
@@ -88,7 +88,7 @@ public class ConfirmationItemViewModel : ViewModelBase
             try
             {
                 await SteamGuardAccount.DenyConfirmationAsync(SdaConfirmation);
-                
+
                 confirmationsViewModel.RemoveViewModel(this);
             }
             catch (RequestException e)

--- a/TradeOnSda/TradeOnSda/Views/Confirmations/ConfirmationsViewModel.cs
+++ b/TradeOnSda/TradeOnSda/Views/Confirmations/ConfirmationsViewModel.cs
@@ -19,9 +19,9 @@ public class ConfirmationsViewModel : ViewModelBase
     public SdaConfirmation[] SdaConfirmations { get; private set; }
 
     public ObservableCollection<ConfirmationItemViewModel> ConfirmationsViewModels { get; }
-    
+
     public ICommand AcceptAllCommand { get; }
-    
+
     public ICommand DenyAllCommand { get; }
 
     public bool IsNoConfirmations
@@ -47,11 +47,14 @@ public class ConfirmationsViewModel : ViewModelBase
             try
             {
                 var newConfirmations = (await steamGuardAccount.FetchConfirmationAsync())
-                    .Where(t => t.ConfirmationType is ConfirmationType.Trade or ConfirmationType.MarketSellTransaction)
+                    .Where(t => t.ConfirmationType is ConfirmationType.Trade
+                        or ConfirmationType.MarketSellTransaction
+                        or ConfirmationType.Recovery
+                        or ConfirmationType.WebKey)
                     .ToArray();
 
                 SdaConfirmations = newConfirmations;
-                
+
                 ConfirmationsViewModels.Clear();
 
                 foreach (var confirmation in newConfirmations)
@@ -80,7 +83,7 @@ public class ConfirmationsViewModel : ViewModelBase
                 await steamGuardAccount.AcceptConfirmationsAsync(SdaConfirmations);
 
                 SdaConfirmations = Array.Empty<SdaConfirmation>();
-                
+
                 ConfirmationsViewModels.Clear();
             }
             catch (RequestException e)
@@ -103,7 +106,7 @@ public class ConfirmationsViewModel : ViewModelBase
                 await steamGuardAccount.DenyConfirmationsAsync(SdaConfirmations);
 
                 SdaConfirmations = Array.Empty<SdaConfirmation>();
-                
+
                 ConfirmationsViewModels.Clear();
             }
             catch (RequestException e)


### PR DESCRIPTION
Removed duplicated logic used in `DoubleClickCommand`