### PR TITLE
Reuse Steam RefreshToken to Refresh Expired AccessToken

### DIFF
--- a/SteamAuthentication/GuardLinking/GuardLinker.cs
+++ b/SteamAuthentication/GuardLinking/GuardLinker.cs
@@ -213,7 +213,7 @@ public class GuardLinker
             addGuardResponse.Response.Status,
             _deviceId,
             true,
-            new SteamSessionData("", "", steamId));
+            new SteamSessionData("", "", "", steamId));
 
         return steamMaFile;
     }

--- a/SteamAuthentication/GuardLinking/GuardLinker.cs
+++ b/SteamAuthentication/GuardLinking/GuardLinker.cs
@@ -65,8 +65,9 @@ public class GuardLinker
             Password = _password,
             IsPersistentSession = false,
             PlatformType = EAuthTokenPlatformType.k_EAuthTokenPlatformType_MobileApp,
-            ClientOSType = EOSType.Android9,
+            ClientOSType = EOSType.AndroidUnknown,
             Authenticator = _authenticator,
+            WebsiteID = "Mobile",
         });
 
         var pollResponse = await authSession.PollingWaitForResultAsync(cancellationToken);

--- a/SteamAuthentication/Logic/JwtTokenValidator.cs
+++ b/SteamAuthentication/Logic/JwtTokenValidator.cs
@@ -1,0 +1,43 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SteamAuthentication.Logic;
+
+public static class JwtTokenValidator
+{
+    public static bool IsTokenExpired(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            throw new ArgumentNullException(nameof(token));
+
+        var tokenParts = token.Split('.');
+        if (tokenParts.Length != 3)
+            throw new ArgumentException("Token is not a valid JWT token.");
+
+        var payload = tokenParts[1];
+
+        var jsonBytes = ParseBase64WithoutPadding(payload);
+        var jsonString = System.Text.Encoding.UTF8.GetString(jsonBytes);
+
+        var payloadData = JsonSerializer.Deserialize<JwtPayload>(jsonString);
+
+        var expirationTime = DateTimeOffset.FromUnixTimeSeconds(payloadData.Exp).UtcDateTime;
+        return expirationTime < DateTime.UtcNow;
+    }
+
+    private static byte[] ParseBase64WithoutPadding(string base64)
+    {
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+        return Convert.FromBase64String(base64.Replace('-', '+').Replace('_', '/'));
+    }
+
+    private class JwtPayload
+    {
+        [JsonPropertyName("exp")]
+        public long Exp { get; set; }
+    }
+}

--- a/SteamAuthentication/LogicModels/SteamGuardAccount.cs
+++ b/SteamAuthentication/LogicModels/SteamGuardAccount.cs
@@ -10,6 +10,7 @@ using SteamAuthentication.Models;
 using SteamAuthentication.Responses;
 using SteamKit2;
 using SteamKit2.Authentication;
+using SteamKit2.Internal;
 
 namespace SteamAuthentication.LogicModels;
 
@@ -435,7 +436,10 @@ public class SteamGuardAccount
                     Username = username,
                     Password = password,
                     IsPersistentSession = true,
+                    PlatformType = EAuthTokenPlatformType.k_EAuthTokenPlatformType_MobileApp,
+                    ClientOSType = EOSType.AndroidUnknown,
                     Authenticator = new SteamGuardAuthenticator(this),
+                    WebsiteID = "Mobile",
                 });
 
             var pollResponse = await authSession.PollingWaitForResultAsync(cancellationToken);

--- a/SteamAuthentication/LogicModels/SteamGuardAccount.cs
+++ b/SteamAuthentication/LogicModels/SteamGuardAccount.cs
@@ -453,7 +453,11 @@ public class SteamGuardAccount
             var steamId = authSession.SteamID.ConvertToUInt64();
             var steamLoginSecure = steamId + "%7C%7C" + pollResponse.AccessToken;
 
-            var newSession = new SteamSessionData(steamClient.ID, steamLoginSecure, steamId);
+            var newSession = new SteamSessionData(
+                steamClient.ID,
+                steamLoginSecure,
+                pollResponse.RefreshToken,
+                steamId);
 
             var newMaFile = new SteamMaFile(
                 MaFile.SharedSecret,

--- a/SteamAuthentication/Models/SteamSessionData.cs
+++ b/SteamAuthentication/Models/SteamSessionData.cs
@@ -17,6 +17,9 @@ public class SteamSessionData
     // [JsonProperty("OAuthToken", Required = Required.Always)]
     // public string OAuthToken { get; private set; } = null!;
 
+    [JsonProperty("RefreshToken")]
+    public string? RefreshToken { get; private set; }
+
     [JsonProperty("SteamID", Required = Required.Always)]
     public ulong SteamId { get; private set; }
 
@@ -26,11 +29,12 @@ public class SteamSessionData
     }
 
     internal SteamSessionData(string sessionId, string steamLoginSecure,
-        ulong steamId)
+        string refreshToken, ulong steamId)
     {
         SessionId = sessionId;
         SteamLoginSecure = steamLoginSecure;
         // OAuthToken = oAuthToken;
+        RefreshToken = refreshToken;
         SteamId = steamId;
     }
 

--- a/TradeOnSda/TradeOnSda/Views/Account/AccountViewModel.cs
+++ b/TradeOnSda/TradeOnSda/Views/Account/AccountViewModel.cs
@@ -338,7 +338,7 @@ public class DefaultAccountViewCommandStrategy : IAccountViewCommandStrategy
     public async Task InvokeSecondCommandAsync()
     {
         try
-        {
+        {   
             var confirmations = await _accountViewModel.SdaWithCredentials.SteamGuardAccount.TryFetchConfirmationAsync();
 
             if (confirmations is null)
@@ -366,9 +366,9 @@ public class DefaultAccountViewCommandStrategy : IAccountViewCommandStrategy
         {
             await NotificationsMessageWindow.ShowWindow($"Cannot load confirmations. {e}", _accountViewModel.OwnerWindow);
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            await NotificationsMessageWindow.ShowWindow("Cannot load confirmations", _accountViewModel.OwnerWindow);
+            await NotificationsMessageWindow.ShowWindow($"Cannot load confirmations, message: {e.Message}", _accountViewModel.OwnerWindow);
         }
     }
 


### PR DESCRIPTION
This pull request implements the functionality to reuse the RefreshToken obtained from Steam during authentication to refresh the AccessToken when it expires. The AccessToken is crucial for accessing the trade confirmations list and other functionalities.

## Changes:

- Added a helper class JwtTokenValidator that contains the logic for checking the token's expiration
- Modified the confirmation list retrieval process to handle AccessToken expiration and refresh it using the RefreshToken

## Affected Areas:

- Retrieval of the confirmation list when triggered by a button press in the interface
- Retrieval of the confirmation list when triggered by a double-click on the corresponding account viewmodel
- Handling AutoConfirm requests for trade confirmations